### PR TITLE
Added .gitignore file to exclude node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
This pull request introduces a .gitignore file to the project. The primary purpose of this file is to exclude the node_modules directory and other unnecessary or auto-generated files from version control. This helps in keeping the repository clean, avoids committing large or redundant files, and ensures faster clone and commit operations.